### PR TITLE
fix: Correção do comportamento dos botoes de revisão

### DIFF
--- a/lib/ui/views/prova/prova.view.dart
+++ b/lib/ui/views/prova/prova.view.dart
@@ -62,14 +62,22 @@ class _ProvaViewState extends BaseStateWidget<ProvaView, ProvaViewStore> with Lo
   @override
   Widget builder(BuildContext context) {
     return Observer(builder: (context) {
-      return _buildProva();
+      return WillPopScope(
+        onWillPop: () async {
+          if (store.revisandoProva) {
+            return false;
+          }
+          return true;
+        },
+        child: _buildProva(),
+      );
     });
   }
 
   Widget _buildProva() {
     if (store.revisandoProva) {
       var questoes = store.questoesParaRevisar.toList();
-      store.totalDeQuestoesParaRevisar = questoes.length-1;
+      store.totalDeQuestoesParaRevisar = questoes.length - 1;
       return PageView.builder(
         physics: NeverScrollableScrollPhysics(),
         controller: listaQuestoesController,

--- a/lib/ui/widgets/appbar/appbar.widget.dart
+++ b/lib/ui/widgets/appbar/appbar.widget.dart
@@ -70,15 +70,24 @@ class AppBarWidget extends StatelessWidget implements PreferredSizeWidget {
 
   Widget _buildBotaoVoltar(BuildContext context) {
     if (mostrarBotaoVoltar) {
-      return IconButton(
-        onPressed: () {
-          Navigator.of(context).pop();
+      return Observer(
+        builder: (_) {
           var prova = GetIt.I.get<ProvaViewStore>();
-          prova.dispose();
+          if (prova.revisandoProva) {
+            return Container();
+          }
+          return IconButton(
+            onPressed: () {
+              if (!prova.revisandoProva) {
+                Navigator.of(context).pop();
+              }
+              prova.dispose();
+            },
+            icon: Icon(
+              Icons.arrow_back,
+            ),
+          );
         },
-        icon: Icon(
-          Icons.arrow_back,
-        ),
       );
     } else {
       return Container();


### PR DESCRIPTION
Mudado estrutura de salvamento das questões para revisão
	- Criado lista de questões para revisar
	- Criado variável que guarda a posição da questão e o total de questões que podem ser revisadas
Mudado estrutura de listagem das questões para responder e para revisar evitando Over Engineering
	- Corrigida logica para saber se vai para revisão ou responder a prova
Mudado comportamento de voltar na tela de resumo
	- Botão de voltar inativo, também não pode mais voltar usando o botão virtual ou físico do dispositivo