### PR TITLE
feat: versão 1.2.2 e melhoria no script de gerar versão

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 .vscode/settings.json
+*.apk

--- a/build-android-release.bat
+++ b/build-android-release.bat
@@ -1,6 +1,22 @@
 @echo off
 
+set version=%1
+
 cmd /c flutter clean
 cmd /c flutter pub get
 cmd /c flutter pub run build_runner build --delete-conflicting-outputs
-cmd /c flutter build apk --release
+cmd /c flutter build apk --release --build-name=%version%
+
+
+for /f "delims=" %%a in ('wmic OS Get localdatetime  ^| find "."') do set dt=%%a
+set YYYY=%dt:~0,4%
+set MM=%dt:~4,2%
+set DD=%dt:~6,2%
+set HH=%dt:~8,2%
+set Min=%dt:~10,2%
+set Sec=%dt:~12,2%
+
+set stamp=%YYYY%-%MM%-%DD%@%HH%-%Min%
+rem you could for example want to create a folder in Gdrive and save backup there %stamp%
+
+copy build\app\outputs\flutter-apk\app-release.apk ".\app-release-v%version%-%stamp%.apk"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.1+1
+version: 1.2.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Uso: `.\build-android-release.bat 1.2.2`
- O arquivo é copiado para a raiz do projeto com o nome `app-release-v1.2.2-2021-10-27@13-27.apk`