### PR TITLE
Remoção do download automático de provas ao realizar o login

### DIFF
--- a/lib/stores/home.store.dart
+++ b/lib/stores/home.store.dart
@@ -163,10 +163,6 @@ abstract class _HomeStoreBase with Store, Loggable, Disposable {
     }
 
     await Prova.salvaProvaCache(provaStore.prova);
-
-    if (provaStore.downloadStatus != EnumDownloadStatus.CONCLUIDO) {
-      provaStore.iniciarDownload();
-    }
   }
 
   @override

--- a/lib/stores/prova.store.dart
+++ b/lib/stores/prova.store.dart
@@ -166,7 +166,7 @@ abstract class _ProvaStoreBase with Store, Loggable, Disposable {
     }
 
     if (resultado == ConnectivityStatus.none && 
-      downloadStatus == EnumDownloadStatus.BAIXANDO) {
+      (downloadStatus == EnumDownloadStatus.BAIXANDO || downloadStatus == EnumDownloadStatus.ERRO)) {
         downloadStatus = EnumDownloadStatus.PAUSADO;
         gerenciadorDownload.pause();
     } else if (resultado != ConnectivityStatus.none && 

--- a/lib/stores/prova.store.dart
+++ b/lib/stores/prova.store.dart
@@ -28,6 +28,7 @@ part 'prova.store.g.dart';
 class ProvaStore = _ProvaStoreBase with _$ProvaStore;
 
 abstract class _ProvaStoreBase with Store, Loggable, Disposable {
+  var _usuarioStore = ServiceLocator.get<UsuarioStore>();
   List<ReactionDisposer> _reactions = [];
 
   @observable
@@ -88,6 +89,11 @@ abstract class _ProvaStoreBase with Store, Loggable, Disposable {
 
   @observable
   bool foraDaPaginaDeRevisao = true;
+
+  @action
+  setRespondendoProva(bool value) {
+    _usuarioStore.setRespondendoProva(value);
+  }
 
   @action
   iniciarDownload() async {
@@ -159,11 +165,13 @@ abstract class _ProvaStoreBase with Store, Loggable, Disposable {
       return;
     }
 
-    if (resultado != ConnectivityStatus.none && downloadStatus != EnumDownloadStatus.BAIXANDO) {
-      await iniciarDownload();
-    } else {
-      downloadStatus = EnumDownloadStatus.PAUSADO;
-      gerenciadorDownload.pause();
+    if (resultado == ConnectivityStatus.none && 
+      downloadStatus == EnumDownloadStatus.BAIXANDO) {
+        downloadStatus = EnumDownloadStatus.PAUSADO;
+        gerenciadorDownload.pause();
+    } else if (resultado != ConnectivityStatus.none && 
+      (downloadStatus == EnumDownloadStatus.PAUSADO || downloadStatus == EnumDownloadStatus.ERRO)) {
+        await iniciarDownload();
     }
   }
 
@@ -266,6 +274,7 @@ abstract class _ProvaStoreBase with Store, Loggable, Disposable {
     try {
       ConnectivityStatus resultado = await (Connectivity().checkConnectivity());
       prova.dataFimProvaAluno = DateTime.now();
+      setRespondendoProva(false);
 
       if (resultado == ConnectivityStatus.none) {
         warning('Prova finalizada sem internet. Sincronização Pendente.');

--- a/lib/stores/usuario.store.dart
+++ b/lib/stores/usuario.store.dart
@@ -46,8 +46,16 @@ abstract class _UsuarioStoreBase with Store {
   @observable
   FonteTipoEnum? familiaFonte = FonteTipoEnum.POPPINS;
 
+  @observable
+  bool isRespondendoProva = false;
+
   @computed
   bool get isLogado => codigoEOL != null;
+
+  @action
+  setRespondendoProva(bool value) {
+    isRespondendoProva = value;
+  }
 
   @action
   void dispose() {

--- a/lib/ui/views/home/tabs/tabs/prova_atual_tab.view.dart
+++ b/lib/ui/views/home/tabs/tabs/prova_atual_tab.view.dart
@@ -421,6 +421,11 @@ class _ProvaAtualTabViewState extends BaseStatelessWidget<ProvaAtualTabView, Hom
       return _buildPausado(provaStore);
     }
 
+    // Download prova error - Download pausado
+    if (provaStore.downloadStatus == EnumDownloadStatus.ERRO) {
+      return _buildPausado(provaStore);
+    }
+
     // Baixar prova
     if (provaStore.downloadStatus == EnumDownloadStatus.NAO_INICIADO && _principalStore.temConexao) {
       return _buildBaixarProva(provaStore);

--- a/lib/ui/views/prova/contexto_prova.view.dart
+++ b/lib/ui/views/prova/contexto_prova.view.dart
@@ -22,6 +22,12 @@ class _ContextoProvaViewState extends State<ContextoProvaView> with Loggable {
   final store = GetIt.I.get<HomeStore>();
 
   @override
+  void initState() {
+    widget.provaStore.setRespondendoProva(true);
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(

--- a/lib/ui/views/prova/prova.view.dart
+++ b/lib/ui/views/prova/prova.view.dart
@@ -72,6 +72,7 @@ class _ProvaViewState extends BaseStateWidget<ProvaView, ProvaViewStore> with Lo
     });
 
     widget.provaStore.foraDaPaginaDeRevisao = true;
+    widget.provaStore.setRespondendoProva(true);
 
     super.initState();
   }

--- a/lib/ui/views/prova/resumo_respostas.view.dart
+++ b/lib/ui/views/prova/resumo_respostas.view.dart
@@ -50,6 +50,7 @@ class _ResumoRespostasViewState extends BaseStateWidget<ResumoRespostasView, Pro
 
   @override
   void dispose() {
+    widget.provaStore.setRespondendoProva(false);
     super.dispose();
   }
 

--- a/lib/workers/jobs/baixar_prova.job.dart
+++ b/lib/workers/jobs/baixar_prova.job.dart
@@ -6,12 +6,16 @@ import 'package:appserap/main.ioc.dart';
 import 'package:appserap/managers/download.manager.dart';
 import 'package:appserap/models/prova.model.dart';
 import 'package:appserap/services/api.dart';
+import 'package:appserap/stores/usuario.store.dart';
 import 'package:appserap/utils/provas.util.dart';
 
 class BaixarProvaJob with Job, Loggable {
   @override
   run() async {
     try {
+      var _usuarioStore = ServiceLocator.get<UsuarioStore>();
+      if (_usuarioStore.isRespondendoProva) return;
+      
       ProvaService provaService = ServiceLocator.get<ApiService>().prova;
 
       var provasResponse = await provaService.getProvas();


### PR DESCRIPTION
1 - remoção do download automático de provas ao realizar o login, 2- ajuste no gerenciamento do downloads de provas ao mudar status da conexão e 3 - adicionada função para NÃO baixar prova em segundo plano ao estar respondendo provas